### PR TITLE
Fix issue with logging in to some Junos Devices

### DIFF
--- a/netconf/Device.php
+++ b/netconf/Device.php
@@ -139,6 +139,7 @@ class Device {
 	while ($flag) {
         switch (expect_expectl($this->stream,array (
                 array("Password:","PASSWORD"),
+                array("password:","PASSWORD"),
                 array("yes/no)?","YESNO"),
                 array("passphrase","PASSPHRASE"),
                 array("]]>]]>","NOPASSPHRASE"),
@@ -148,6 +149,7 @@ class Device {
 		    fwrite($this->stream,$this->password."\n");
                     switch (expect_expectl($this->stream,array (
                         array("Password:","PASSWORD"),
+                        array("password:","PASSWORD"),
                         array("]]>]]>","hello"),
                         ))) { 
                         case "PASSWORD":
@@ -162,6 +164,7 @@ class Device {
                     fwrite($this->stream,$this->password."\n");
                     switch (expect_expectl($this->stream,array (
                         array("Password:","PASSWORD"),
+                        array("password:","PASSWORD"),
                         array("]]>]]>","hello"),
                         ))) {
                         case "PASSWORD":


### PR DESCRIPTION
Not all juniper devices return "Password:" at the ssh login screen, Some only reply with a small p ("password:"), Because of this i have added an extra case check that will launch the same case.
Tested on Junos 11.4R2.14
