### PR TITLE
Fix typo in Device.php

### DIFF
--- a/netconf/Device.php
+++ b/netconf/Device.php
@@ -185,7 +185,7 @@ class Device {
                 case "SHELL":
                     break;
 		case EXP_EOF :
-		    throw new NetconfExpection("Timeout Connecting to device");
+		    throw new NetconfException("Timeout Connecting to device");
                 default:
                     throw new NetconfException("Device not found/ unknown error occurred while connecting to Device");
                 }


### PR DESCRIPTION
There is een typo in the Device.php code which causes issues on timeouts
